### PR TITLE
feat: close system panels on click outside

### DIFF
--- a/src/Taskbar.svelte
+++ b/src/Taskbar.svelte
@@ -72,6 +72,7 @@
     </div>
     <div
       class="taskIcon widgetBtn hvrBgLight"
+      class:bgLight={$activeThing === "Widgets"}
       on:click={() => toggleActiveThing("Widgets")}
       on:keypress={() => toggleActiveThing("Widgets")}
     >

--- a/src/components/ActionCenter.svelte
+++ b/src/components/ActionCenter.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { IconButton, Slider } from "fluent-svelte";
   import { fly } from "svelte/transition";
-  import { brightness, speaker } from "$store";
+  import { brightness, speaker, activeThing } from "$store";
   import Battery from "./shared/Battery.svelte";
   import Speaker from "./shared/Speaker.svelte";
+  import clickOutside from "$lib/clickOutside";
 
   const items = [
     { title: "WiFi", active: true, icon: "wifi" },
@@ -18,6 +19,7 @@
 <div
   class="actionCenter activeShadow"
   transition:fly={{ y: 450, duration: 200, opacity: 1 }}
+  use:clickOutside={() => ($activeThing = "")}
 >
   <div class="topCont">
     <div class="btnCont">

--- a/src/components/ActionCenter.svelte
+++ b/src/components/ActionCenter.svelte
@@ -19,7 +19,10 @@
 <div
   class="actionCenter activeShadow"
   transition:fly={{ y: 450, duration: 200, opacity: 1 }}
-  use:clickOutside={() => ($activeThing = "")}
+  use:clickOutside={{
+    callback: () => ($activeThing = ""),
+    exclude: [document.querySelector(".bgLight")],
+  }}
 >
   <div class="topCont">
     <div class="btnCont">

--- a/src/components/Calendar.svelte
+++ b/src/components/Calendar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { CalendarView, Button } from "fluent-svelte";
   import { fly } from "svelte/transition";
-  import { date } from "$store";
+  import { date, activeThing } from "$store";
+  import clickOutside from "$lib/clickOutside";
 
   let collapse = false;
 </script>
@@ -10,6 +11,10 @@
   class="calnpane activeShadow"
   class:collapse
   transition:fly={{ x: 400, duration: 200, opacity: 1 }}
+  use:clickOutside={{
+    callback: () => ($activeThing = ""),
+    exclude: [document.querySelector(".bgLight")],
+  }}
 >
   <div class="topBar">
     <div class="date">

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -2,6 +2,7 @@
   import { TextBox } from "fluent-svelte";
   import { fly } from "svelte/transition";
   import { activeThing, openedApps } from "$store";
+  import clickOutside from "$lib/clickOutside";
 
   const topApp = [
     "Settings",
@@ -25,6 +26,7 @@
 <div
   class="search activeShadow"
   transition:fly={{ y: 700, duration: 200, opacity: 1 }}
+  use:clickOutside={() => ($activeThing = "")}
 >
   <TextBox placeholder="Type here to search" autofocus />
 

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -26,7 +26,10 @@
 <div
   class="search activeShadow"
   transition:fly={{ y: 700, duration: 200, opacity: 1 }}
-  use:clickOutside={() => ($activeThing = "")}
+  use:clickOutside={{
+    callback: () => ($activeThing = ""),
+    exclude: [document.querySelector(".bgLight")],
+  }}
 >
   <TextBox placeholder="Type here to search" autofocus />
 

--- a/src/components/Start.svelte
+++ b/src/components/Start.svelte
@@ -29,7 +29,10 @@
 <div
   class="start activeShadow"
   transition:fly={{ y: 700, duration: 200, opacity: 1 }}
-  use:clickOutside={() => ($activeThing = "")}
+  use:clickOutside={{
+    callback: () => ($activeThing = ""),
+    exclude: [document.querySelector(".bgLight")],
+  }}
 >
   <div class="topCont">
     <TextBox

--- a/src/components/Start.svelte
+++ b/src/components/Start.svelte
@@ -2,6 +2,7 @@
   import { Button, MenuFlyout, MenuFlyoutItem, TextBox } from "fluent-svelte";
   import { fly } from "svelte/transition";
   import { activeThing, appList, openedApps } from "$store";
+  import clickOutside from "$lib/clickOutside";
 
   let allApps = false;
 
@@ -28,6 +29,7 @@
 <div
   class="start activeShadow"
   transition:fly={{ y: 700, duration: 200, opacity: 1 }}
+  use:clickOutside={() => ($activeThing = "")}
 >
   <div class="topCont">
     <TextBox

--- a/src/components/Widgets.svelte
+++ b/src/components/Widgets.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { ProgressRing, TextBox } from "fluent-svelte";
   import { fly } from "svelte/transition";
-  import { date } from "$store";
+  import { date, activeThing } from "$store";
+  import clickOutside from "$lib/clickOutside";
 
   const time_elapsed_toString = (publishTime: number) => {
     const etime = (Date.now() - publishTime) / 1000;
@@ -37,7 +38,14 @@
   })();
 </script>
 
-<div class="widgets" transition:fly={{ x: -800, duration: 200, opacity: 1 }}>
+<div
+  class="widgets"
+  transition:fly={{ x: -800, duration: 200, opacity: 1 }}
+  use:clickOutside={{
+    callback: () => ($activeThing = ""),
+    exclude: [document.querySelector(".bgLight")],
+  }}
+>
   <div class="time">
     {$date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
   </div>

--- a/src/lib/clickOutside.js
+++ b/src/lib/clickOutside.js
@@ -1,18 +1,18 @@
 export default function clickOutside(element, callbackFunction) {
-    function onClick(event) {
-        if (!element.contains(event.target)) {
-            callbackFunction();
-        }
+  function onClick(event) {
+    if (!element.contains(event.target)) {
+      callbackFunction();
     }
+  }
 
-    document.body.addEventListener('click', onClick);
+  document.body.addEventListener("click", onClick);
 
-    return {
-        update(newCallbackFunction) {
-            callbackFunction = newCallbackFunction;
-        },
-        destroy() {
-            document.body.removeEventListener('click', onClick);
-        }
-    }
+  return {
+    update(newCallbackFunction) {
+      callbackFunction = newCallbackFunction;
+    },
+    destroy() {
+      document.body.removeEventListener("click", onClick);
+    },
+  };
 }

--- a/src/lib/clickOutside.js
+++ b/src/lib/clickOutside.js
@@ -1,0 +1,18 @@
+export default function clickOutside(element, callbackFunction) {
+    function onClick(event) {
+        if (!element.contains(event.target)) {
+            callbackFunction();
+        }
+    }
+
+    document.body.addEventListener('click', onClick);
+
+    return {
+        update(newCallbackFunction) {
+            callbackFunction = newCallbackFunction;
+        },
+        destroy() {
+            document.body.removeEventListener('click', onClick);
+        }
+    }
+}

--- a/src/lib/clickOutside.js
+++ b/src/lib/clickOutside.js
@@ -1,7 +1,14 @@
-export default function clickOutside(element, callbackFunction) {
+export default function clickOutside(
+  element,
+  options = { callback: () => {}, exclude: [] }
+) {
   function onClick(event) {
-    if (!element.contains(event.target)) {
-      callbackFunction();
+    if (
+      !element.contains(event.target) &&
+      !options.exclude.map((e) => e.contains(event.target)).includes(true) &&
+      typeof options.callback === "function"
+    ) {
+      options.callback();
     }
   }
 
@@ -9,7 +16,7 @@ export default function clickOutside(element, callbackFunction) {
 
   return {
     update(newCallbackFunction) {
-      callbackFunction = newCallbackFunction;
+      options.callback = newCallbackFunction;
     },
     destroy() {
       document.body.removeEventListener("click", onClick);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "paths": {
       "$apps/*": ["src/apps/*"],
       "$store": ["src/store.ts"],
-      "$components/*": ["src/components/*"]
+      "$components/*": ["src/components/*"],
+      "$lib/*": ["src/lib/*"],
     }
   },
   "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
       "$apps/*": ["src/apps/*"],
       "$store": ["src/store.ts"],
       "$components/*": ["src/components/*"],
-      "$lib/*": ["src/lib/*"],
+      "$lib/*": ["src/lib/*"]
     }
   },
   "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       $store: path.resolve(__dirname, "./src/store"),
       $apps: path.resolve(__dirname, "./src/apps"),
       $components: path.resolve(__dirname, "./src/components"),
+      $lib: path.resolve(__dirname, "./src/lib"),
     },
   },
 });


### PR DESCRIPTION
Windows 11 allows system panels (start, search and action center) to be closed by clicking outside.

This pull aims to add this behavior.

### Report of changes made with this pull
- created `lib` folder
- added `lib` folder to "aliases"
- added `clickOutside.js` to the `lib` folder
- changed `ActionCenter.svelte`, `Search.svelte` and `Start.svelte` to add the "click-outside" behavior.
